### PR TITLE
GCI task: added code that populates "fedora_user" field

### DIFF
--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -97,7 +97,7 @@ class FedoraRpm < ActiveRecord::Base
   end
 
   def retrieve_versions
-    puts "Importing rpm #{name} versions"
+    puts "Importing rpm #{name} versions and maintainer"
     self.rpm_versions.clear
     self.dependencies.clear
     FEDORA_VERSIONS.each do |version_title, version_git|
@@ -106,7 +106,7 @@ class FedoraRpm < ActiveRecord::Base
       begin
         rpm_spec = URI.parse(spec_url).read
         is_patched = (rpm_spec.scan(/\nPatch0:\s*.*\n/).size != 0)
-
+        
         rpm_version = rpm_spec.scan(/\nVersion:\s*.*\n/).first.split.last
         if !version_valid?(rpm_version)
           if rpm_version.include?('%{majorver}')
@@ -121,6 +121,19 @@ class FedoraRpm < ActiveRecord::Base
         rv.is_patched = is_patched
         self.rpm_versions << rv
         if version_title == 'rawhide'
+          #Import the maintainer's e-mail            
+          fedora_user_list = rpm_spec.scan(/<.*>/)
+          fedora_user_list.each do |user|
+            if user != "<rel-eng@lists.fedoraproject.org>" #We don't want to add Fedora Release Engineering
+              #Remove those "<>"
+              user[0] = ""    
+              user.gsub!(">", "")
+              self.fedora_user = user
+              break
+            end
+          end
+          puts "Maintainer: #{self.fedora_user}"
+            
           self.homepage = rpm_spec.scan(/\nURL:\s*.*\n/).first.split.last
 
           rpm_spec.split("\n").each { |line|
@@ -136,6 +149,7 @@ class FedoraRpm < ActiveRecord::Base
             end
           }
         end
+
       rescue Exception => e
         puts "Could not retrieve version of #{name} for #{version_title}"
       end

--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -122,12 +122,12 @@ class FedoraRpm < ActiveRecord::Base
         self.rpm_versions << rv
         if version_title == 'rawhide'
           #Import the maintainer's e-mail            
-          fedora_user_list = rpm_spec.scan(/<.*>/)
+          fedora_user_list = rpm_spec.scan(/<.*[@].*>/)
           fedora_user_list.each do |user|
             if user != "<rel-eng@lists.fedoraproject.org>" #We don't want to add Fedora Release Engineering
               #Remove those "<>"
-              user[0] = ""    
-              user.gsub!(">", "")
+              user[0] = ""
+              user.gsub!(">", "")                  
               self.fedora_user = user
               break
             end
@@ -151,7 +151,7 @@ class FedoraRpm < ActiveRecord::Base
         end
 
       rescue Exception => e
-        puts "Could not retrieve version of #{name} for #{version_title}"
+        puts "Could not retrieve version of #{name} for #{version_title}: #{e}"
       end
     end
   end
@@ -281,6 +281,10 @@ class FedoraRpm < ActiveRecord::Base
       rpms << $1 if l =~ /Wrote: (.*)/
     }
     rpms
+  end
+  
+  def get_obfuscated_fedora_user
+    return self.fedora_user.to_s.gsub("@", " AT ").gsub(".", " DOT ")
   end
 
 private

--- a/app/views/fedorarpms/index.html.haml
+++ b/app/views/fedorarpms/index.html.haml
@@ -11,6 +11,7 @@
       %th= sortable "commits", "Git Commits"
       %th= sortable "last_commit_date", "Last Commit"
       %th= "Upstream Source Patched?"
+      %th= "Maintainer"
 
   %tbody
     - @rpms.each do |rpm|
@@ -23,6 +24,7 @@
         %td= rpm.last_commit_date.nil? ? '' : time_ago_in_words(rpm.last_commit_date) + " ago"
         %td= rpm.patched?
         / %td= link_to rpm.ruby_gem.name, rubygem_path(rpm.ruby_gem.name) if rpm.ruby_gem != nil
+        %td= rpm.get_obfuscated_fedora_user
 
 %div.pagination
   = will_paginate @rpms

--- a/app/views/fedorarpms/show.html.haml
+++ b/app/views/fedorarpms/show.html.haml
@@ -12,7 +12,7 @@
       %span.label.label-success= 'Yes'
     - else
       %span.label.label-important= 'No'
-
+  %label= "Maintainer: #{@rpm.get_obfuscated_fedora_user}"
   %label= "Versions: #{@rpm.versions}"
   %label= "Git Commits: #{@rpm.commits}"
   %label= "Depends on:"


### PR DESCRIPTION
Please review thoroughly this patch - my Internet connection doesn't allow me to fully test it.

Changes to be committed:

```
modified:   app/models/fedora_rpm.rb
```

added code that populates the "fedora_user" field in fedora_rpms
