### PR TITLE
IMPORT LAST_UPDATED DATE INTO THE BUGS TABLE

### DIFF
--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -176,10 +176,11 @@ class FedoraRpm < ActiveRecord::Base
     bugzilla_search = URI.parse(bugzilla_url).read
     doc = Nokogiri::HTML(bugzilla_search)
 
-    # get bugs and their titles
+    # get bugs and their titles and last_updated
     bugs = doc.xpath("//td[@class='bz_short_desc_column']/a").collect { |bz| [bz.attr('href').gsub('show_bug.cgi?id=', ''), bz.text.strip] }
     bugs.each { |bug|
-      arb = Bug.new :name => bug.last, :bz_id => bug.first
+      update = doc.xpath("//tr[@id='b#{bug.first}']//td[@class='bz_changeddate_column']").text
+      arb = Bug.new :name => bug.last, :bz_id => bug.first, :last_updated => update
       arb.is_review = true if arb.name =~ /^Review Request.*#{name}\s.*$/
       self.bugs << arb
     }

--- a/db/migrate/20121208152321_add_last_updated_to_bugs.rb
+++ b/db/migrate/20121208152321_add_last_updated_to_bugs.rb
@@ -1,0 +1,5 @@
+class AddLastUpdatedToBugs < ActiveRecord::Migration
+  def change
+    add_column :bugs, :last_updated, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121015133744) do
+ActiveRecord::Schema.define(:version => 20121208152321) do
 
   create_table "bugs", :force => true do |t|
     t.string   "name"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(:version => 20121015133744) do
     t.boolean  "is_review"
     t.datetime "created_at",    :null => false
     t.datetime "updated_at",    :null => false
+    t.string   "last_updated"
   end
 
   create_table "builds", :force => true do |t|


### PR DESCRIPTION
So as to be able to display bugzilla data on a fedora gem activity timeline, i import the timestamp corresponding to when the bug was last updated into the isitfedoraruby webapp.
