### PR TITLE
Add Visualization to isitfedoraruby

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -4,6 +4,23 @@ class StatsController < ApplicationController
     @gems = RubyGem.order('downloads desc').limit(10)
   end
 
+  def user_rpms_data
+    @name = params[:stat_id]
+    @rpms = FedoraRpm.where("fedora_user LIKE ?", @name + "@%")
+    respond_to do |format|
+      format.json { render json: @rpms.to_json }
+    end
+  end
+
+  def user_rpms
+    @name = params[:stat_id]
+    @rpms = FedoraRpm.where("fedora_user LIKE ?", @name + "@%")
+    @rpms_json = @rpms.to_json
+    respond_to do |format|
+      format.html
+    end
+  end
+
   def gemfile_tool
     if params[:gemfile]
       @gemfile = params[:gemfile]

--- a/app/views/stats/user_rpms.html.haml
+++ b/app/views/stats/user_rpms.html.haml
@@ -6,6 +6,7 @@
 
 :javascript
   var r = 700
+    color = d3.scale.category20c();
   var bubble_layout = d3.layout.pack()
       .sort(null)
       .size([r,r])
@@ -30,9 +31,10 @@
   node = selection.enter().append("g")
                 .attr("class", "node")
                 .attr("transform", function(d) { return "translate(" + d.x + ", " + d.y + ")"; });
+  fill = d3.scale.category20c();
   node.append("circle")
       .attr("r", function(d) { return d.r; })
-      .style("fill", function(d) { return (Math.floor((Math.random()*210)+45).toString(16))+(Math.floor((Math.random()*210)+45).toString(16))+(Math.floor((Math.random()*210)+45).toString(16)); });
+      .style("fill", function(d) { return color(d.name); });
 
   node.append("text")
       .on("click", function(d, i) { window.location = '/fedorarpms/rubygem-' + d.name; })

--- a/app/views/stats/user_rpms.html.haml
+++ b/app/views/stats/user_rpms.html.haml
@@ -1,0 +1,44 @@
+.d3_chart_container
+  %h1= "Bubble Chart:"
+  %h2= "This graph shows the packages, which are represented by circles, that the user #{@name} owns."
+  %h2= "The size of each circle is proportional to the number of commits for that package."
+  #chart
+
+:javascript
+  var r = 700
+  var bubble_layout = d3.layout.pack()
+      .sort(null)
+      .size([r,r])
+      .padding(1.5);
+
+  var vis = d3.select("#chart").append("svg")
+      .attr("width" , r)
+      .attr("height", r)
+
+  var array = #{@rpms_json}
+
+  arr = [];
+  for (i = 0; i < array.length; i++)
+  {
+    arr[i] = { "name": array[i]["name"].split("rubygem-")[1], "value": array[i]["commits"]}
+  }
+
+
+  var selection = vis.selectAll("g.node")
+                .data(bubble_layout.nodes({children: arr}).filter(function(d) { return !d.children; }) ); 
+  //Enter
+  node = selection.enter().append("g")
+                .attr("class", "node")
+                .attr("transform", function(d) { return "translate(" + d.x + ", " + d.y + ")"; });
+  node.append("circle")
+      .attr("r", function(d) { return d.r; })
+      .style("fill", function(d) { return (Math.floor((Math.random()*210)+45).toString(16))+(Math.floor((Math.random()*210)+45).toString(16))+(Math.floor((Math.random()*210)+45).toString(16)); });
+
+  node.append("text")
+      .on("click", function(d, i) { window.location = '/fedorarpms/rubygem-' + d.name; })
+      .on("mouseover", function() { document.body.style.cursor = 'pointer'; })
+      .on("mouseout", function() { document.body.style.cursor = 'default'; })
+      .attr("text-anchor", "middle")
+      .attr("dy", ".3em")
+      .style("font-color", "FFF")
+      .text(function(d) { return d.name.substring(0, d.r/3);; });

--- a/app/views/stats/user_rpms.html.haml
+++ b/app/views/stats/user_rpms.html.haml
@@ -31,7 +31,6 @@
   node = selection.enter().append("g")
                 .attr("class", "node")
                 .attr("transform", function(d) { return "translate(" + d.x + ", " + d.y + ")"; });
-  fill = d3.scale.category20c();
   node.append("circle")
       .attr("r", function(d) { return d.r; })
       .style("fill", function(d) { return color(d.name); });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Isitfedoraruby::Application.routes.draw do
 
   resources :stats do
     get :gemfile_tool, :on => :collection
+    get :user_rpms
+    get :user_rpms_data
     post :gemfile_tool, :on => :collection
   end
 


### PR DESCRIPTION
This creates a visualization of the packages that any given fedora user owns. It uses the d3.js library in order to do so. In order to view the visualization, you must go to /stats/USERNAME/user_rpms and the JSON used to produce the page can be viewed at /stats/USERNAME/user_rpms_data.

Features:
- Displays the data in a visually appealing way
- Size of each circle is proportional to the number of commits for that particular package
- Circle colors are randomly generated
- Dark circle colors are excluded in order to keep the text readable
- Each node is linked to its particular package for easy access
