### PR TITLE
Not found error and suggestions for FedoraRPMs

### DIFF
--- a/app/controllers/fedorarpms_controller.rb
+++ b/app/controllers/fedorarpms_controller.rb
@@ -13,8 +13,9 @@ class FedorarpmsController < ApplicationController
     @page_title = @rpm.name
     @dependencies = @rpm.dependency_packages
     @dependents = @rpm.dependent_packages
+    #We can register a global error handler inside the application controller for this.
     rescue ActiveRecord::RecordNotFound
-    redirect_to :action => 'not_found'     
+      redirect_to :action => 'not_found'     
  
   end
 

--- a/app/controllers/fedorarpms_controller.rb
+++ b/app/controllers/fedorarpms_controller.rb
@@ -9,11 +9,19 @@ class FedorarpmsController < ApplicationController
 
   def show
     @name = params[:id]
-    @rpm = FedoraRpm.find_by_name(@name, :include => :rpm_comments)
+    @rpm = FedoraRpm.find_by_name!(@name, :include => :rpm_comments)
     @page_title = @rpm.name
     @dependencies = @rpm.dependency_packages
     @dependents = @rpm.dependent_packages
+    rescue ActiveRecord::RecordNotFound
+    redirect_to :action => 'not_found'     
+ 
   end
+
+  def not_found
+    @rpm = params[:id]
+    @results = FedoraRpm.where('name LIKE ?', "%#{@rpm}%")
+  end 
 
   def full_deps
     @name = params[:id]

--- a/app/views/fedorarpms/not_found.html.haml
+++ b/app/views/fedorarpms/not_found.html.haml
@@ -16,8 +16,3 @@ as a Fedora RPM; please check your URL and try again.
       - @results.each do |r|
         %tr
           %td= link_to r.rpm_name, fedorarpm_path(r.rpm_name)
-          
-
-
-
-

--- a/app/views/fedorarpms/not_found.html.haml
+++ b/app/views/fedorarpms/not_found.html.haml
@@ -1,0 +1,23 @@
+%h1 RPM Not Found 
+
+Sorry, we couldn't find 
+%b=@rpm 
+as a Fedora RPM; please check your URL and try again.
+%br/ 
+%br/
+- if @results != []
+
+  %table.table.table-striped.table-condensed
+    %thead
+      %tr
+        %th Did you mean:
+       
+    %tbody
+      - @results.each do |r|
+        %tr
+          %td= link_to r.rpm_name, fedorarpm_path(r.rpm_name)
+          
+
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Isitfedoraruby::Application.routes.draw do
     get :full_dependents,   :on => :member
     get :by_owner, :on => :member
     get :badge, :on => :member
+    get :not_found, :on => :member
   end
   resources :rubygems, :constraints => { :id => /.*/ }
   resources :searches


### PR DESCRIPTION
Added 'not found' errors and 'did you mean' suggestions to FedoraRPMs. 
(shown while browsing http://isitfedoraruby.com/fedorarpms/non-existent-rpm)
