### PR TITLE
Use Fedora Package Api to import Builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'nokogiri'
 gem 'versionomy'
 gem 'gems'
 gem 'recaptcha', :require => 'recaptcha/rails'
+gem 'pkgwat'
 
 group :test, :development do
   gem 'rspec-rails'

--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -195,12 +195,11 @@ class FedoraRpm < ActiveRecord::Base
     puts "Importing rpm #{name} builds"
     self.builds.clear
 
-    @@koji_search ||= XMLRPC::Client.new2(Build::KOJI_API_URL)
-    builds = @@koji_search.call "search", name, "build", "regexp"
+    builds = Pkgwat.get_builds(name)
     builds.each { |build|
       bld = Build.new
-      bld.name = build['name']
-      bld.build_id = build['id']
+      bld.name = build['nvr']
+      bld.build_id = build['build_id']
       self.builds << bld
     }
   end

--- a/app/models/rpm_importer.rb
+++ b/app/models/rpm_importer.rb
@@ -3,7 +3,6 @@ require 'open-uri'
 class RpmImporter
 
   BASE_URI = 'http://pkgs.fedoraproject.org/cgit/'
-  PKG_LIST_URI = BASE_URI + '?q=rubygem-'
 
   def self.import_oldest(number)
     total = 0
@@ -45,29 +44,22 @@ class RpmImporter
   end
 
   def self.import_rpms_list
-    offset = 0
-    loop do
-      list_page = URI.parse(PKG_LIST_URI + '&ofs=' + offset.to_s).read
-      doc = Nokogiri::HTML(list_page)
-      rpms = doc.xpath("//tr/td[@class='toplevel-repo']/a/@title")
-      break if rpms.empty?
-      rpms.each { |rpm|
-        rpm_name = rpm.value.gsub(/\.git.*/,'')
-        puts "Importing rpm #{rpm_name}"
-        if FedoraRpm.find_by_name(rpm_name).nil?
-          r = FedoraRpm.new
-          r.name = rpm_name
-          r.source_uri = "git://pkgs.fedoraproject.org/#{rpm}"
-          r.save!
-        else
-          puts "rpm #{rpm_name} already imported"
-        end
-      }
-      offset += 50
-    end
+    rpms = Pkgwat.get_packages("rubygem")
+    rpms.each {|rpm|
+      rpm_name = rpm["name"]
+      puts "Importing rpm #{rpm_name}"
+      if FedoraRpm.find_by_name(rpm_name).nil?  
+        r = FedoraRpm.new
+        r.name = rpm_name
+        r.source_uri = "git://pkgs.fedoraproject.org/#{rpm_name}"
+        r.save!
+      else
+        puts "rpm #{rpm_name} already imported"
+      end
+    }
     puts "Rpms list imported."
-  rescue Exception => ex
-    puts "Import failed due to eror #{ex}."
+    rescue Exception => ex
+      puts "Import failed due to eror #{ex}."
   end
 
   def self.update_rpms(days_since_last_update, mode)


### PR DESCRIPTION
Instead of scrapping data from koji build system, I added Fedora Package Api (pkgwat) for importing builds.
