### PR TITLE
Use Bugzilla api to retrieve bugs and their titles and last_update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'versionomy'
 gem 'gems'
 gem 'recaptcha', :require => 'recaptcha/rails'
 gem 'pkgwat'
+gem 'ruby-bugzilla'
 
 group :test, :development do
   gem 'rspec-rails'

--- a/app/models/fedora_rpm.rb
+++ b/app/models/fedora_rpm.rb
@@ -1,5 +1,6 @@
 require 'versionomy'
 require 'xmlrpc/client'
+require 'bugzilla'
 
 class FedoraRpm < ActiveRecord::Base
   FEDORA_VERSIONS = {'rawhide'   => 'master',


### PR DESCRIPTION
Instead of scrapping bugs from bugzilla.redhat.com website , i edits retrieve_bugs method to use Bugzilla api to retrieve the bugs's data.
